### PR TITLE
[sample buildouts] freeze python dateutil to version 2.3

### DIFF
--- a/buildouts/odoo-80.cfg
+++ b/buildouts/odoo-80.cfg
@@ -13,3 +13,4 @@ eggs = pyPdf
 
 [versions]
 reportlab = 2.7
+python-dateutil = 2.3

--- a/buildouts/odoo-master.cfg
+++ b/buildouts/odoo-master.cfg
@@ -13,3 +13,4 @@ eggs = pyPdf
 
 [versions]
 reportlab = 2.7
+python-dateutil = 2.3


### PR DESCRIPTION
4 Days ago a new version of [python dateutil](https://github.com/dateutil/dateutil/releases) was released which broke [buildout sample test](https://buildbot.anybox.fr/builders/odoo-80-postgresql-9.3/builds/626).