### PR TITLE
sample buildouts: pin werkzeug on stable 0.9 versions

### DIFF
--- a/buildouts/odoo-master.cfg
+++ b/buildouts/odoo-master.cfg
@@ -14,3 +14,4 @@ eggs = pyPdf
 [versions]
 reportlab = 2.7
 python-dateutil = 2.3
+werkzeug = < 0.10


### PR DESCRIPTION
same as commit e8ab3cd72fcb240a72e5575b6ac62a60086a07f9 on buildouts/odoo-80.cfg