### PR TITLE
Revert "sample buildouts: pin werkzeug on stable 0.9 versions"

### DIFF
--- a/buildouts/odoo-master.cfg
+++ b/buildouts/odoo-master.cfg
@@ -14,4 +14,3 @@ eggs = pyPdf
 [versions]
 reportlab = 2.7
 python-dateutil = 2.3
-werkzeug = < 0.10


### PR DESCRIPTION
Reverts anybox/anybox.buildbot.odoo#7 as version 0.10.4 fixed this issue. cf odoo/odoo#5057
